### PR TITLE
Refactor improve query type safety

### DIFF
--- a/src/cbor/partial.ts
+++ b/src/cbor/partial.ts
@@ -44,8 +44,11 @@ export function partiallyEncodeObject<Q extends string>(
 	object: SurqlQueryBindings<Q> | Record<never, never>,
 	options?: EncoderOptions<true>,
 ): WithPartiallyEncodeValues<SurqlQueryBindings<Q>, PartiallyEncoded> {
+	// it can happen that the bindings are undefined  and typescript complains
+	// so we need to add a little check
+	const o = object ?? {};
 	return Object.fromEntries(
-		Object.entries(object).map(([k, v]) => [
+		Object.entries(o).map(([k, v]) => [
 			k,
 			encode(v, { ...options, partial: true }),
 		]),

--- a/src/cbor/partial.ts
+++ b/src/cbor/partial.ts
@@ -1,3 +1,4 @@
+import type { SurqlQueryBindings, WithPartiallyEncodeValues } from "../types";
 import type { Replacer } from "./constants";
 import { type EncoderOptions, encode } from "./encoder";
 import { CborFillMissing } from "./error";
@@ -39,14 +40,14 @@ export class PartiallyEncoded {
 	}
 }
 
-export function partiallyEncodeObject(
-	object: Record<string, unknown>,
+export function partiallyEncodeObject<Q extends string>(
+	object: SurqlQueryBindings<Q> | Record<never, never>,
 	options?: EncoderOptions<true>,
-): Record<string, PartiallyEncoded> {
+): WithPartiallyEncodeValues<SurqlQueryBindings<Q>, PartiallyEncoded> {
 	return Object.fromEntries(
 		Object.entries(object).map(([k, v]) => [
 			k,
 			encode(v, { ...options, partial: true }),
 		]),
-	);
+	) as WithPartiallyEncodeValues<SurqlQueryBindings<Q>, PartiallyEncoded>;
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -26,3 +26,9 @@ export {
 	GeometryPolygon,
 } from "./types/geometry.ts";
 export { encodeCbor, decodeCbor } from "./cbor.ts";
+
+export type {
+	AssertValidSurqlValue,
+	SurqlQueryBindingValue,
+	SurqlFuture,
+} from "./types/querybindingvalues.ts";

--- a/src/data/types/future.ts
+++ b/src/data/types/future.ts
@@ -1,10 +1,11 @@
 import { Value } from "../value";
+import type { SurqlFuture } from "./querybindingvalues";
 
 /**
  * An uncomputed SurrealQL future value.
  */
-export class Future extends Value {
-	constructor(readonly inner: string) {
+export class Future<F extends string> extends Value {
+	constructor(readonly inner: F) {
 		super();
 	}
 
@@ -17,7 +18,7 @@ export class Future extends Value {
 		return this.toString();
 	}
 
-	toString(): string {
+	toString(): SurqlFuture<F> {
 		return `<future> ${this.inner}`;
 	}
 }

--- a/src/data/types/querybindingvalues.ts
+++ b/src/data/types/querybindingvalues.ts
@@ -81,8 +81,8 @@ export type MustBeSurqlValue<V> = V extends Date
 								? V
 								: V extends RecordId
 									? V
-									: V extends unknown
-										? V
-										: V extends string
-											? AssertValidSurqlValue<V>
+									: V extends string
+										? AssertValidSurqlValue<V>
+										: V extends unknown
+											? V
 											: never;

--- a/src/data/types/querybindingvalues.ts
+++ b/src/data/types/querybindingvalues.ts
@@ -1,5 +1,6 @@
 import type { Gap } from "../../cbor";
 import type { RecordId, StringRecordId } from "./recordid";
+import type { Table } from "./table";
 import type { Uuid } from "./uuid";
 export type SurqlFuture<F extends string> = `<future> ${F}`;
 
@@ -46,6 +47,7 @@ export type SurqlQueryBindingValue =
 	| Uuid
 	| boolean
 	| Gap
+	| Table
 	| number;
 
 export type AssertValidSurqlValue<
@@ -63,22 +65,24 @@ export type AssertValidSurqlValue<
 
 export type MustBeSurqlValue<V> = V extends Date
 	? V
-	: V extends boolean
+	: V extends Table
 		? V
-		: V extends Gap
+		: V extends boolean
 			? V
-			: V extends number
+			: V extends Gap
 				? V
-				: V extends Uuid
+				: V extends number
 					? V
-					: V extends StringRecordId
+					: V extends Uuid
 						? V
-						: V extends Date
+						: V extends StringRecordId
 							? V
-							: V extends RecordId
+							: V extends Date
 								? V
-								: V extends unknown
+								: V extends RecordId
 									? V
-									: V extends string
-										? AssertValidSurqlValue<V>
-										: never;
+									: V extends unknown
+										? V
+										: V extends string
+											? AssertValidSurqlValue<V>
+											: never;

--- a/src/data/types/querybindingvalues.ts
+++ b/src/data/types/querybindingvalues.ts
@@ -1,0 +1,84 @@
+import type { Gap } from "../../cbor";
+import type { RecordId, StringRecordId } from "./recordid";
+import type { Uuid } from "./uuid";
+export type SurqlFuture<F extends string> = `<future> ${F}`;
+
+export type SocketConnectionVariables<K extends string, V> = Record<K, V>;
+
+type BrandedError<Msg extends string, T> = T & { __brand: Msg };
+type SqlKeyword =
+	| "SELECT"
+	| "INSERT"
+	| "UPDATE"
+	| "DELETE"
+	| "CREATE"
+	| "DROP"
+	| "select"
+	| "insert"
+	| "update"
+	| "delete"
+	| "create"
+	| "drop";
+type IsSurqlQuery<T extends string> = T extends `${SqlKeyword} ${string}`
+	? true
+	: false;
+
+type IsRecord<T extends string> = T extends `${string}:${string}`
+	? true
+	: false;
+
+type IsUuid<T extends string> =
+	T extends `${string}-${string}-${string}-${string}-${string}` ? true : false;
+
+type IsIsoDate<T extends string> =
+	T extends `${number}-${number}-${number}T${number}:${number}:${number}.${number}Z`
+		? true
+		: T extends `${number}-${number}-${number}T${number}:${number}:${number}Z` // Without milliseconds
+			? true
+			: false;
+
+export type SurqlQueryBindingValue =
+	| SurqlFuture<string>
+	| Date
+	| string
+	| StringRecordId
+	| RecordId
+	| Uuid
+	| boolean
+	| Gap
+	| number;
+
+export type AssertValidSurqlValue<
+	T extends string,
+	V extends SurqlQueryBindingValue = SurqlQueryBindingValue,
+> = IsIsoDate<T> extends true
+	? BrandedError<"Use d`…` for ISO-dates", T>
+	: IsUuid<T> extends true
+		? BrandedError<"Use u`…` instead for UUIDs", T>
+		: IsRecord<T> extends true
+			? BrandedError<"Use r`…` instead for record IDs", T>
+			: IsSurqlQuery<T> extends true
+				? BrandedError<"Use f`…` instead for futures", T>
+				: V;
+
+export type MustBeSurqlValue<V> = V extends Date
+	? V
+	: V extends boolean
+		? V
+		: V extends Gap
+			? V
+			: V extends number
+				? V
+				: V extends Uuid
+					? V
+					: V extends StringRecordId
+						? V
+						: V extends Date
+							? V
+							: V extends RecordId
+								? V
+								: V extends unknown
+									? V
+									: V extends string
+										? AssertValidSurqlValue<V>
+										: never;

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -13,21 +13,24 @@ import {
 	type EngineEvents,
 	type Engines,
 } from "./engines/abstract.ts";
-import { Emitter } from "./util/emitter.ts";
-import { PreparedQuery } from "./util/prepared-query.ts";
-import { versionCheck } from "./util/version-check.ts";
-
 import type {
 	ActionResult,
 	ConnectOptions,
+	ExecuteRawSurqlQuery,
+	ExecuteSurqlQuery,
 	ExportOptions,
 	LiveHandler,
 	MapQueryResult,
+	ParallelSurqlQueryBindingsArray,
 	Patch,
 	Prettify,
 	QueryParameters,
 	RpcResponse,
+	SurqlQueryBindings,
 } from "./types.ts";
+import { Emitter } from "./util/emitter.ts";
+import { PreparedQuery } from "./util/prepared-query.ts";
+import { versionCheck } from "./util/version-check.ts";
 
 import { AuthController } from "./auth.ts";
 import { type Fill, partiallyEncodeObject } from "./cbor";
@@ -234,6 +237,7 @@ export class Surreal extends AuthController {
 	 * @param key - Specifies the name of the variable.
 	 * @param val - Assigns the value to the variable name.
 	 */
+
 	async let(variable: string, value: unknown): Promise<true> {
 		const res = await this.rpc("let", [variable, value]);
 		if (res.error) throw new ResponseError(res.error.message);
@@ -332,18 +336,40 @@ export class Surreal extends AuthController {
 	}
 
 	/**
-	 * Runs a set of SurrealQL statements against the database.
-	 * @param query - Specifies the SurrealQL statements.
-	 * @param bindings - Assigns variables which can be used in the query.
+	 * Executes a single SurrealQL query against the database with optional variable bindings.
+	 *
+	 * This method allows dynamic SurrealQL execution with parameter substitution. Variables in the query
+	 * should be prefixed with `$` (e.g., `$id`) and are replaced by values provided in the `bindings` object.
+	 *
+	 * Example usage:
+	 * ```ts
+	 * const result = await db.query(
+	 *   'SELECT * FROM user WHERE id = $id',
+	 *   { id: '123' }
+	 * ).execute();
+	 * ```
+	 *
+	 * @template Q - A SurrealQL query string.
+	 * @template B - A bindings object corresponding to variables in the query string.
+	 *
+	 * @param {...QueryParameters<Q, B>} args - A tuple consisting of a query string and its associated bindings object.
+	 * @returns {{
+	 *   execute<T>(): Promise<[T]>
+	 * }} An object with an `execute` method that performs the query and returns the result in a typed array.
 	 */
-	async query<T extends unknown[]>(
-		...args: QueryParameters
-	): Promise<Prettify<T>> {
-		const raw = await this.queryRaw<T>(...args);
-		return raw.map(({ status, result }) => {
-			if (status === "ERR") throw new ResponseError(result);
-			return result;
-		}) as T;
+	query<Q extends string, B extends SurqlQueryBindings<Q>>(
+		...args: QueryParameters<Q, B>
+	): ExecuteSurqlQuery {
+		const self = this;
+		return {
+			async execute<T extends unknown[T]>(): Promise<Prettify<[T]>> {
+				const raw = await self.queryRaw<Q>(...args).execute<T>();
+				return raw.map(({ status, result }) => {
+					if (status === "ERR") throw new ResponseError(result);
+					return result;
+				}) as [T];
+			},
+		};
 	}
 
 	/**
@@ -351,24 +377,104 @@ export class Surreal extends AuthController {
 	 * @param query - Specifies the SurrealQL statements.
 	 * @param bindings - Assigns variables which can be used in the query.
 	 */
-	async queryRaw<T extends unknown[]>(
-		...[q, b]: QueryParameters
-	): Promise<Prettify<MapQueryResult<T>>> {
-		const params =
-			q instanceof PreparedQuery
-				? [
-						q.query,
-						partiallyEncodeObject(q.bindings, {
-							fills: b as Fill[],
-							replacer: replacer.encode,
-						}),
-					]
-				: [q, b];
+	queryRaw<Q extends string>(
+		...[q, b]: QueryParameters<Q>
+	): ExecuteRawSurqlQuery {
+		const self = this;
+		return {
+			async execute<T extends unknown[T]>(): Promise<
+				Prettify<MapQueryResult<T>>
+			> {
+				const params =
+					q instanceof PreparedQuery
+						? [
+								q.query,
+								partiallyEncodeObject(q.bindings, {
+									fills: b as Fill[],
+									replacer: replacer.encode,
+								}),
+							]
+						: [q, b];
 
-		await this.ready;
-		const res = await this.rpc<MapQueryResult<T>>("query", params);
-		if (res.error) throw new ResponseError(res.error.message);
-		return res.result;
+				await self.ready;
+				const res = await self.rpc<MapQueryResult<T>>("query", params);
+				if (res.error) throw new ResponseError(res.error.message);
+				return res.result;
+			},
+		};
+	}
+
+	/**
+	 * Executes multiple SurrealQL queries against the database, with optional bindings for each query.
+	 *
+	 * This function takes an array of SurrealQL query strings and a corresponding array of binding objects.
+	 * It substitutes variables in each query using the bindings, concatenates all queries into a single SurrealQL string,
+	 * and prepares an executable object that runs the combined query when `.execute()` is called.
+	 *
+	 * Each variable in the query string should be prefixed with `$` (e.g. `$id`), and will be replaced by the corresponding
+	 * value in the bindings object. If no bindings are provided for a query, it will be executed as-is.
+	 *
+	 * Example usage:
+	 * ```ts
+	 * const result = await db.parallelQuery(
+	 *   ['SELECT * FROM user WHERE id = $id', 'SELECT * FROM post WHERE title = $title'],
+	 *   [{ id: '123' }, { title: 'Hello' }]
+	 * ).execute();
+	 * ```
+	 *
+	 * @template Qs - A readonly tuple of query strings.
+	 * @template Bindings - A readonly tuple of bindings corresponding to the query strings.
+	 *
+	 * @param {readonly [...Qs]} queries - An array of SurrealQL queries to execute.
+	 * @param {readonly [...Bindings]} bindings - An array of bindings for each query, where each binding is an object mapping keys to values used in the corresponding query.
+	 * @returns {{
+	 *   execute<T>(): Promise<[T]>
+	 * }} An object with an `execute` method that runs the constructed query and returns the typed result.
+	 */
+	queryMany<
+		const Qs extends readonly string[],
+		const Bindings extends ParallelSurqlQueryBindingsArray<Qs>,
+	>(
+		queries: readonly [...Qs],
+		bindings: readonly [...Bindings],
+	): ExecuteSurqlQuery {
+		let finalQuery = "";
+		for (let i = 0; i <= queries.length - 1; i++) {
+			let query = queries[i];
+			const binding = bindings[i];
+			if (typeof query !== "string") {
+				continue;
+			}
+			if (typeof query !== "string" && typeof binding === "undefined") {
+				continue;
+			}
+			if (typeof binding === "undefined") {
+				if (query.endsWith(";")) {
+					finalQuery += query;
+					continue;
+				}
+				finalQuery += `${query};`;
+				continue;
+			}
+			for (const key of Object.keys(binding)) {
+				query = query.replace(`$${key}`, `"${binding[key]}"`);
+			}
+			if (query.endsWith(";")) {
+				finalQuery += query;
+			} else {
+				finalQuery += `${query};`;
+			}
+		}
+		const self = this;
+		return {
+			async execute<T extends unknown[T]>(): Promise<Prettify<[T]>> {
+				const raw = await self.queryRaw(finalQuery).execute<T>();
+				return raw.map(({ status, result }) => {
+					if (status === "ERR") throw new ResponseError(result);
+					return result;
+				}) as [T];
+			},
+		};
 	}
 
 	/**
@@ -378,9 +484,9 @@ export class Surreal extends AuthController {
 	 * @deprecated Use `queryRaw` instead
 	 */
 	async query_raw<T extends unknown[]>(
-		...args: QueryParameters
-	): Promise<Prettify<MapQueryResult<T>>> {
-		return this.queryRaw<T>(...args);
+		...args: QueryParameters<string>
+	): Promise<Prettify<MapQueryResult<[T]>>> {
+		return await this.queryRaw(...args).execute<T>();
 	}
 
 	/**

--- a/src/surreal.ts
+++ b/src/surreal.ts
@@ -6,6 +6,7 @@ import {
 	decodeCbor,
 	encodeCbor,
 } from "./data";
+import type { SurqlQueryBindingValue } from "./data";
 import {
 	type AbstractEngine,
 	ConnectionStatus,
@@ -439,8 +440,11 @@ export class Surreal extends AuthController {
 		bindings: readonly [...Bindings],
 	): ExecuteSurqlQuery {
 		let finalQuery = "";
+
+		const finalBindings: Record<string, SurqlQueryBindingValue> = {};
+
 		for (let i = 0; i <= queries.length - 1; i++) {
-			let query = queries[i];
+			const query = queries[i];
 			const binding = bindings[i];
 			if (typeof query !== "string") {
 				continue;
@@ -457,7 +461,7 @@ export class Surreal extends AuthController {
 				continue;
 			}
 			for (const key of Object.keys(binding)) {
-				query = query.replace(`$${key}`, `"${binding[key]}"`);
+				finalBindings[key] = binding[key];
 			}
 			if (query.endsWith(";")) {
 				finalQuery += query;
@@ -468,7 +472,9 @@ export class Surreal extends AuthController {
 		const self = this;
 		return {
 			async execute<T extends unknown[T]>(): Promise<Prettify<[T]>> {
-				const raw = await self.queryRaw(finalQuery).execute<T>();
+				const raw = await self
+					.queryRaw(finalQuery, finalBindings as unknown as undefined)
+					.execute<T>();
 				return raw.map(({ status, result }) => {
 					if (status === "ERR") throw new ResponseError(result);
 					return result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,154 @@
 import type { AuthController } from "./auth";
-import type { Fill } from "./cbor";
 import { type RecordId, Uuid } from "./data";
+
+import type { Fill } from "./cbor";
+import type {
+	MustBeSurqlValue,
+	SurqlQueryBindingValue,
+} from "./data/types/querybindingvalues";
 import { SurrealDbError } from "./errors";
 import type { Surreal } from "./surreal";
 import type { PreparedQuery } from "./util/prepared-query";
 
+//////////////////////////////////////////////
+//////////   QUERY Binding TYPES   //////////
+//////////////////////////////////////////////
+export type ConcatStrings<
+	A extends string,
+	B extends readonly string[],
+> = B extends []
+	? A
+	: B extends [infer Head extends string, ...infer Tail extends string[]]
+		? ConcatStrings<`${A} ${Head}`, Tail>
+		: A;
+
+type IdentChar =
+	| "_"
+	| "$"
+	| "0"
+	| "1"
+	| "2"
+	| "3"
+	| "4"
+	| "5"
+	| "6"
+	| "7"
+	| "8"
+	| "9"
+	| "A"
+	| "B"
+	| "C"
+	| "D"
+	| "E"
+	| "F"
+	| "G"
+	| "H"
+	| "I"
+	| "J"
+	| "K"
+	| "L"
+	| "M"
+	| "N"
+	| "O"
+	| "P"
+	| "Q"
+	| "R"
+	| "S"
+	| "T"
+	| "U"
+	| "V"
+	| "W"
+	| "X"
+	| "Y"
+	| "Z"
+	| "a"
+	| "b"
+	| "c"
+	| "d"
+	| "e"
+	| "f"
+	| "g"
+	| "h"
+	| "i"
+	| "j"
+	| "k"
+	| "l"
+	| "m"
+	| "n"
+	| "o"
+	| "p"
+	| "q"
+	| "r"
+	| "s"
+	| "t"
+	| "u"
+	| "v"
+	| "w"
+	| "x"
+	| "y"
+	| "z";
+
+type SplitIdent<
+	S extends string,
+	Acc extends string = "",
+> = S extends `${infer First}${infer Rest}`
+	? First extends IdentChar
+		? SplitIdent<Rest, `${Acc}${First}`>
+		: [Acc, S]
+	: [Acc, ""];
+
+type ExtractDollarWords<S extends string> =
+	S extends `${infer _Before}$${infer After}`
+		? SplitIdent<After> extends [
+				infer Key extends string,
+				infer Rem extends string,
+			]
+			? (Key extends "" ? never : Key) | ExtractDollarWords<Rem>
+			: never
+		: never;
+
+type BindingsFor<Keys extends string, V> = {
+	[K in Keys]: V;
+};
+
+export type WithPartiallyEncodeValues<T, V> = {
+	[K in keyof T]: V;
+};
+type EnforceSurqlValues<T> = {
+	[K in keyof T]: MustBeSurqlValue<T[K]>;
+};
+type ReservedBindingNames =
+	| "this"
+	| "parent"
+	| "access"
+	| "auth"
+	| "token"
+	| "session";
+export type RustFnParams<S extends string> =
+	S extends `${infer _Pre}${infer _Class}::${infer _Func}(${infer Body})${infer Rest}`
+		? ExtractDollarWords<Body> | RustFnParams<Rest>
+		: never;
+
+export type SurqlQueryBindings<Q extends string> = Exclude<
+	ExtractDollarWords<Q>,
+	ReservedBindingNames | RustFnParams<Q>
+> extends infer Keys
+	? [Keys] extends [never]
+		? Record<never, never> | undefined
+		: {
+				[K in Extract<Keys & string, string>]: MustBeSurqlValue<
+					BindingsFor<K, SurqlQueryBindingValue>[K]
+				>;
+			}
+	: never;
+
+export type ParallelSurqlQueryBindingsArray<Qs extends readonly string[]> = {
+	[I in keyof Qs]: SurqlQueryBindings<Qs[I]> extends infer R
+		? [keyof R] extends [never]
+			? undefined
+			: EnforceSurqlValues<R>
+		: never;
+};
 export type ActionResult<T extends Record<string, unknown>> = Prettify<
 	T["id"] extends RecordId ? T : { id: RecordId } & T
 >;
@@ -13,9 +157,33 @@ export type Prettify<T> = {
 	[K in keyof T]: T[K];
 } & {}; // deno-lint-ignore ban-types
 
-export type QueryParameters =
-	| [query: string, bindings?: Record<string, unknown>]
-	| [prepared: PreparedQuery, gaps?: Fill[]];
+export type ExecuteSurqlQuery = {
+	execute<T extends unknown[T]>(): Promise<Prettify<[T]>>;
+};
+export type ExecuteRawSurqlQuery = {
+	execute<T extends unknown[T]>(): Promise<Prettify<MapQueryResult<[T]>>>;
+};
+
+type FinalBinding<B> = B extends undefined
+	? undefined
+	: { [K in keyof B]: MustBeSurqlValue<B[K]> };
+type IsEmptyBindings<T> = T extends undefined | Record<string, never>
+	? true
+	: false;
+export type QueryParameters<
+	Q extends string,
+	B extends SurqlQueryBindings<Q> = SurqlQueryBindings<Q>,
+> = IsEmptyBindings<B> extends true
+	?
+			| [query: Q]
+			| [query: Q, bindings: undefined]
+			| [
+					prepared: PreparedQuery<string, Record<never, never> | undefined>,
+					gaps?: Fill[],
+			  ]
+	:
+			| [query: Q, bindings: FinalBinding<B>]
+			| [prepared: PreparedQuery<Q, B>, gaps?: Fill[]];
 
 //////////////////////////////////////////////
 //////////   AUTHENTICATION TYPES   //////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,9 +111,7 @@ type BindingsFor<Keys extends string, V> = {
 	[K in Keys]: V;
 };
 
-export type WithPartiallyEncodeValues<T, V> = {
-	[K in keyof T]: V;
-};
+export type WithPartiallyEncodeValues<T, V> = Record<keyof T, V>;
 type EnforceSurqlValues<T> = {
 	[K in keyof T]: MustBeSurqlValue<T[K]>;
 };
@@ -177,13 +175,10 @@ export type QueryParameters<
 	?
 			| [query: Q]
 			| [query: Q, bindings: undefined]
-			| [
-					prepared: PreparedQuery<string, Record<never, never> | undefined>,
-					gaps?: Fill[],
-			  ]
+			| [prepared: PreparedQuery<string>, gaps?: Fill[]]
 	:
 			| [query: Q, bindings: FinalBinding<B>]
-			| [prepared: PreparedQuery<Q, B>, gaps?: Fill[]];
+			| [prepared: PreparedQuery<Q>, gaps?: Fill[]];
 
 //////////////////////////////////////////////
 //////////   AUTHENTICATION TYPES   //////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,17 +129,22 @@ export type RustFnParams<S extends string> =
 
 export type SurqlQueryBindings<Q extends string> = Exclude<
 	ExtractDollarWords<Q>,
-	ReservedBindingNames | RustFnParams<Q>
-> extends infer Keys
-	? [Keys] extends [never]
+	ReservedBindingNames
+> extends infer AllBindings
+	? [AllBindings] extends [never]
 		? Record<never, never> | undefined
 		: {
-				[K in Extract<Keys & string, string>]: MustBeSurqlValue<
-					BindingsFor<K, SurqlQueryBindingValue>[K]
-				>;
+				[K in Extract<
+					Exclude<AllBindings, RustFnParams<Q>> & string,
+					string
+				>]: MustBeSurqlValue<BindingsFor<K, SurqlQueryBindingValue>[K]>;
+			} & {
+				[K in Extract<
+					Extract<AllBindings, RustFnParams<Q>> & string,
+					string
+				>]?: MustBeSurqlValue<BindingsFor<K, SurqlQueryBindingValue>[K]>;
 			}
 	: never;
-
 export type ParallelSurqlQueryBindingsArray<Qs extends readonly string[]> = {
 	[I in keyof Qs]: SurqlQueryBindings<Qs[I]> extends infer R
 		? [keyof R] extends [never]

--- a/src/util/jsonify.ts
+++ b/src/util/jsonify.ts
@@ -16,7 +16,7 @@ export type Jsonify<T> = T extends
 	| Uuid
 	| Decimal
 	| Duration
-	| Future
+	| Future<string>
 	| Range<unknown, unknown>
 	| StringRecordId
 	? string

--- a/src/util/prepared-query.ts
+++ b/src/util/prepared-query.ts
@@ -8,6 +8,13 @@ import {
 	partiallyEncodeObject,
 } from "../cbor";
 import { replacer } from "../data/cbor";
+import type { MustBeSurqlValue } from "../data/types/querybindingvalues";
+import type {
+	ConcatStrings,
+	ParallelSurqlQueryBindingsArray,
+	SurqlQueryBindings,
+	WithPartiallyEncodeValues,
+} from "../types";
 
 let textEncoder: TextEncoder;
 
@@ -16,15 +23,26 @@ export type ConvertMethod<T = unknown> = (result: unknown[]) => T;
 /**
  * A query and its bindings prepared for execution, which can be passed to the .query() method.
  */
-export class PreparedQuery {
+export class PreparedQuery<
+	const Q extends string = string,
+	const B extends SurqlQueryBindings<Q> = SurqlQueryBindings<Q>,
+> {
 	private _query: Uint8Array;
-	private _bindings: Record<string, PartiallyEncoded>;
+	private _bindings: WithPartiallyEncodeValues<
+		SurqlQueryBindings<Q>,
+		PartiallyEncoded
+	>;
 	private length: number;
 
-	constructor(query: string, bindings?: Record<string, unknown>) {
+	constructor(
+		query: Q,
+		bindings: {
+			[K in keyof B]: MustBeSurqlValue<B[K]>;
+		},
+	) {
 		textEncoder ??= new TextEncoder();
 		this._query = textEncoder.encode(query);
-		this._bindings = partiallyEncodeObject(bindings ?? {}, {
+		this._bindings = partiallyEncodeObject<Q>(bindings ?? {}, {
 			replacer: replacer.encode,
 		});
 		this.length = Object.keys(this._bindings).length;
@@ -44,7 +62,10 @@ export class PreparedQuery {
 	/**
 	 * Retrieves the encoded bindings.
 	 */
-	get bindings(): Record<string, PartiallyEncoded> {
+	get bindings(): WithPartiallyEncodeValues<
+		SurqlQueryBindings<Q>,
+		PartiallyEncoded
+	> {
 		return this._bindings;
 	}
 
@@ -67,10 +88,16 @@ export class PreparedQuery {
 	 *   query.append` WHERE name = ${filter}`;
 	 * }
 	 */
-	append(
-		query_raw: string[] | TemplateStringsArray,
-		...values: unknown[]
-	): PreparedQuery {
+	append<
+		const Qs extends readonly string[],
+		const Bindings extends ParallelSurqlQueryBindingsArray<Qs>,
+	>(
+		query_raw: readonly [...Qs] | TemplateStringsArray,
+		values: readonly [...Bindings],
+	): PreparedQuery<
+		ConcatStrings<Q, Qs>,
+		SurqlQueryBindings<ConcatStrings<Q, Qs>>
+	> {
 		const base = this.length;
 		this.length += values.length;
 

--- a/src/util/prepared-query.ts
+++ b/src/util/prepared-query.ts
@@ -132,12 +132,4 @@ export class PreparedQuery<const Q extends string = string> {
 	}
 }
 
-const query = new PreparedQuery("Select * from table where id  = $id", {
-	id: "",
-});
 
-const updatedQuery = query.append(
-	["Select * from hello world where hello_word = $hello_world"],
-	[{ hello_world: "some" }],
-);
-const bindings = updatedQuery.bindings;

--- a/src/util/prepared-query.ts
+++ b/src/util/prepared-query.ts
@@ -10,13 +10,13 @@ import {
 import { replacer } from "../data/cbor";
 import type {
 	ConcatStrings,
-	ParallelSurqlQueryBindingsArray,
 	SurqlQueryBindings,
 	WithPartiallyEncodeValues,
 } from "../types";
 
 let textEncoder: TextEncoder;
 
+type BindingOrGap<Q extends string> = SurqlQueryBindings<Q> | Gap;
 export type ConvertMethod<T = unknown> = (result: unknown[]) => T;
 
 /**
@@ -81,7 +81,9 @@ export class PreparedQuery<const Q extends string = string> {
 	 */
 	append<
 		const Qs extends readonly string[],
-		const Bindings extends ParallelSurqlQueryBindingsArray<Qs>,
+		const Bindings extends {
+			[I in keyof Qs]: BindingOrGap<Qs[I]>;
+		},
 	>(
 		query_raw: readonly [...Qs] | TemplateStringsArray,
 		values: readonly [...Bindings],
@@ -106,6 +108,7 @@ export class PreparedQuery<const Q extends string = string> {
 		});
 
 		for (const [k, v] of mapped_bindings) {
+			// @ts-expect-error: we know “k” may not be in keyof SurqlQueryBindings<Q>
 			this._bindings[k] = encode(v, {
 				replacer: replacer.encode,
 				partial: true,
@@ -128,3 +131,13 @@ export class PreparedQuery<const Q extends string = string> {
 		return this;
 	}
 }
+
+const query = new PreparedQuery("Select * from table where id  = $id", {
+	id: "",
+});
+
+const updatedQuery = query.append(
+	["Select * from hello world where hello_word = $hello_world"],
+	[{ hello_world: "some" }],
+);
+const bindings = updatedQuery.bindings;

--- a/src/util/prepared-query.ts
+++ b/src/util/prepared-query.ts
@@ -8,7 +8,6 @@ import {
 	partiallyEncodeObject,
 } from "../cbor";
 import { replacer } from "../data/cbor";
-import type { MustBeSurqlValue } from "../data/types/querybindingvalues";
 import type {
 	ConcatStrings,
 	ParallelSurqlQueryBindingsArray,
@@ -23,10 +22,7 @@ export type ConvertMethod<T = unknown> = (result: unknown[]) => T;
 /**
  * A query and its bindings prepared for execution, which can be passed to the .query() method.
  */
-export class PreparedQuery<
-	const Q extends string = string,
-	const B extends SurqlQueryBindings<Q> = SurqlQueryBindings<Q>,
-> {
+export class PreparedQuery<const Q extends string = string> {
 	private _query: Uint8Array;
 	private _bindings: WithPartiallyEncodeValues<
 		SurqlQueryBindings<Q>,
@@ -34,12 +30,7 @@ export class PreparedQuery<
 	>;
 	private length: number;
 
-	constructor(
-		query: Q,
-		bindings: {
-			[K in keyof B]: MustBeSurqlValue<B[K]>;
-		},
-	) {
+	constructor(query: Q, bindings: SurqlQueryBindings<Q>) {
 		textEncoder ??= new TextEncoder();
 		this._query = textEncoder.encode(query);
 		this._bindings = partiallyEncodeObject<Q>(bindings ?? {}, {
@@ -94,10 +85,7 @@ export class PreparedQuery<
 	>(
 		query_raw: readonly [...Qs] | TemplateStringsArray,
 		values: readonly [...Bindings],
-	): PreparedQuery<
-		ConcatStrings<Q, Qs>,
-		SurqlQueryBindings<ConcatStrings<Q, Qs>>
-	> {
+	): PreparedQuery<ConcatStrings<Q, Qs>> {
 		const base = this.length;
 		this.length += values.length;
 

--- a/src/util/string-prefixes.ts
+++ b/src/util/string-prefixes.ts
@@ -1,4 +1,5 @@
-import { StringRecordId, Uuid } from "../data";
+import { Future, StringRecordId, Uuid } from "../data";
+import type { SurqlFuture } from "../data/types/querybindingvalues";
 
 /**
  * A template literal tag function for parsing a string type
@@ -27,6 +28,18 @@ export function d(
 	...values: unknown[]
 ): Date {
 	return new Date(s(string, values));
+}
+/**
+ * A template literal tag function for parsing a string into a future
+ * @param string - The string to parse
+ * @param values - The interpolated values
+ * @returns The parsed future string
+ */
+export function f(
+	string: string[] | TemplateStringsArray,
+	...values: unknown[]
+): SurqlFuture<string> {
+	return new Future(s(string, values)).toString();
 }
 
 /**

--- a/tests/integration/tests/auth.test.ts
+++ b/tests/integration/tests/auth.test.ts
@@ -74,6 +74,7 @@ describe("record auth", async () => {
     			SIGNUP ( CREATE type::thing('user', $id) )
     			SIGNIN ( SELECT * FROM type::thing('user', $id) );
     	`,
+				{},
 			)
 			.execute();
 	});

--- a/tests/integration/tests/auth.test.ts
+++ b/tests/integration/tests/auth.test.ts
@@ -32,6 +32,7 @@ describe("scope auth", async () => {
     			SIGNUP ( CREATE type::thing('user', $id) )
     			SIGNIN ( SELECT * FROM type::thing('user', $id) );
     	`,
+				{},
 			)
 			.execute();
 	});

--- a/tests/integration/tests/auth.test.ts
+++ b/tests/integration/tests/auth.test.ts
@@ -24,12 +24,16 @@ describe("scope auth", async () => {
 	if (!version.startsWith("surrealdb-1")) return;
 
 	beforeAll(async () => {
-		await surreal.query(/* surql */ `
+		await surreal
+			.query(
+				/* surql */ `
     		DEFINE TABLE user PERMISSIONS FOR select WHERE id = $auth;
     		DEFINE SCOPE user
     			SIGNUP ( CREATE type::thing('user', $id) )
     			SIGNIN ( SELECT * FROM type::thing('user', $id) );
-    	`);
+    	`,
+			)
+			.execute();
 	});
 
 	test("scope signup", async () => {
@@ -62,12 +66,16 @@ describe("record auth", async () => {
 	if (version.startsWith("surrealdb-1")) return;
 
 	beforeAll(async () => {
-		await surreal.query(/* surql */ `
+		await surreal
+			.query(
+				/* surql */ `
     		DEFINE TABLE user PERMISSIONS FOR select WHERE id = $auth;
     		DEFINE ACCESS user ON DATABASE TYPE RECORD
     			SIGNUP ( CREATE type::thing('user', $id) )
     			SIGNIN ( SELECT * FROM type::thing('user', $id) );
-    	`);
+    	`,
+			)
+			.execute();
 	});
 
 	test("record signup", async () => {

--- a/tests/integration/tests/connection.test.ts
+++ b/tests/integration/tests/connection.test.ts
@@ -44,7 +44,7 @@ describe("rpc", async () => {
 		});
 
 		expect(async () => {
-			await surreal.query("SELECT * FROM test");
+			await surreal.query("SELECT * FROM test", undefined).execute();
 		}).toThrow();
 	});
 });
@@ -62,7 +62,7 @@ describe("prepare", async () => {
 			},
 		});
 
-		await surreal.query("CREATE example");
+		await surreal.query("CREATE example", undefined).execute();
 	});
 
 	test("authentication with prepare over http", async () => {
@@ -77,6 +77,6 @@ describe("prepare", async () => {
 			},
 		});
 
-		await surreal.query("CREATE example");
+		await surreal.query("CREATE example", undefined).execute();
 	});
 });

--- a/tests/integration/tests/export.test.ts
+++ b/tests/integration/tests/export.test.ts
@@ -9,11 +9,15 @@ const { createSurreal } = await setupServer();
 beforeAll(async () => {
 	const surreal = await createSurreal();
 
-	await surreal.query(surql`
+	await surreal
+		.query(
+			surql`
 		CREATE foo:1 CONTENT { hello: "world" };
 		CREATE bar:1 CONTENT { hello: "world" };
 		DEFINE FUNCTION fn::foo() { RETURN "bar"; };
-	`);
+	`,
+		)
+		.execute();
 });
 
 describe("export", async () => {

--- a/tests/integration/tests/import.test.ts
+++ b/tests/integration/tests/import.test.ts
@@ -15,9 +15,14 @@ describe("import", async () => {
 			CREATE foo:1 CONTENT { hello: "world" };
 		`);
 
-		const res = await surreal.query(/* surql */ `
+		const res = await surreal
+			.query(
+				/* surql */ `
 			SELECT * FROM foo;
-		`);
+		`,
+				undefined,
+			)
+			.execute();
 
 		expect(res).toMatchSnapshot();
 	});

--- a/tests/integration/tests/querying.test.ts
+++ b/tests/integration/tests/querying.test.ts
@@ -8,8 +8,10 @@ import {
 	GeometryMultiPolygon,
 	GeometryPoint,
 	GeometryPolygon,
+	PreparedQuery,
 	RecordId,
 	StringRecordId,
+	type SurqlQueryBindingValue,
 	Table,
 	Uuid,
 	surql,
@@ -396,7 +398,7 @@ describe("template literal", async () => {
 	test("with gap", async () => {
 		const name = new Gap();
 		const query = surql`CREATE ONLY person:test SET name = ${name}`;
-		const res = await surreal.query(query, [name.fill("test")]);
+		const res = await surreal.query(query, [name.fill("test")]).execute();
 		expect(res).toStrictEqual([
 			{
 				id: new RecordId("person", "test"),
@@ -409,14 +411,14 @@ describe("template literal", async () => {
 		await surreal.let("test1", 123);
 		const gap = new Gap<number>();
 		const query = surql`RETURN [$test1, ${456}, ${gap}]`;
-		const res = await surreal.query(query, [gap.fill(789)]);
+		const res = await surreal.query(query, [gap.fill(789)]).execute();
 		expect(res).toStrictEqual([[123, 456, 789]]);
 	});
 
 	test("has replacer context", async () => {
 		const id = new RecordId("test", 123);
 		const query = surql`RETURN ${id}`;
-		const res = await surreal.query(query);
+		const res = await surreal.query(query).execute();
 		expect(res).toStrictEqual([id]);
 	});
 
@@ -427,10 +429,12 @@ describe("template literal", async () => {
 
 		// Append to it
 		const age = new Gap();
-		query.append`, age = ${age}`;
+		query.append([`, age = ${age}`], [undefined]);
 
 		// Check result
-		const res = await surreal.query(query, [name.fill("append"), age.fill(20)]);
+		const res = await surreal
+			.query(query, [name.fill("append"), age.fill(20)])
+			.execute();
 
 		expect(res).toStrictEqual([
 			{
@@ -444,7 +448,15 @@ describe("template literal", async () => {
 	test("reused gap", async () => {
 		const foo = new Gap();
 		const bar = new Gap();
-		const query = surql`RETURN [${foo}, ${bar}, ${1}, ${foo}, ${bar}, ${2}]`;
+
+		//string literals cant provid typesafety
+		//const query = surql`RETURN [${foo},${bar}, ${1}, ${foo}, ${bar}, ${2}]`;
+		const query = new PreparedQuery("RETURN [$foo,$bar, $1, $foo, $bar, $2]", {
+			foo: foo,
+			bar: bar,
+			"1": 1,
+			"2": 2,
+		});
 		expect(Object.keys(query.bindings)).toStrictEqual([
 			"bind___0",
 			"bind___1",
@@ -453,7 +465,10 @@ describe("template literal", async () => {
 		]);
 
 		// Ensure appended segments also re-use
-		query.append`; RETURN [${foo}, ${bar}, ${1}, ${foo}, ${bar}, ${2}]`;
+		query.append(
+			["; RETURN [$foo, $bar, $1, $foo, $bar, $2]"],
+			[{ foo: foo, bar: bar, "1": 1, "2": 2 }],
+		);
 		expect(Object.keys(query.bindings)).toStrictEqual([
 			"bind___0",
 			"bind___1",
@@ -466,7 +481,9 @@ describe("template literal", async () => {
 		]);
 
 		// Check result
-		const res = await surreal.query(query, [foo.fill("a"), bar.fill("b")]);
+		const [res] = await surreal
+			.query(query, [foo.fill("a"), bar.fill("b")])
+			.execute<[string, string, number, string, string, number][]>();
 
 		expect(res).toStrictEqual([
 			["a", "b", 1, "a", "b", 2],
@@ -487,12 +504,13 @@ describe("value encoding/decoding", async () => {
 	) => {
 		const runner = todo ? test.todoIf(true) : test.if(cond ?? true);
 		runner(name, async () => {
-			const [output] = await surreal.query<[typeof input]>(
-				/* surql */ "$input",
-				{
-					input,
-				},
-			);
+			const [output] = await surreal
+				.query(/* surql */ "$input", {
+					//because of value validation we need to cast unknown values
+					//explicit to SurqlQueryBindingValue
+					input: input as SurqlQueryBindingValue,
+				})
+				.execute<typeof input>();
 
 			expect(output).toStrictEqual(input);
 		});
@@ -567,12 +585,11 @@ describe("value encoding/decoding", async () => {
 test("record id bigint", async () => {
 	const surreal = await createSurreal();
 
-	const [output] = await surreal.query<[{ id: RecordId }]>(
-		/* surql */ "CREATE ONLY $id",
-		{
+	const [output] = await surreal
+		.query(/* surql */ "CREATE ONLY $id", {
 			id: new RecordId("person", 90071992547409915n),
-		},
-	);
+		})
+		.execute<{ id: RecordId }>();
 
 	expect(output.id).toStrictEqual(new RecordId("person", 90071992547409915n));
 });
@@ -580,12 +597,11 @@ test("record id bigint", async () => {
 test("string record id", async () => {
 	const surreal = await createSurreal();
 
-	const [output] = await surreal.query<[{ id: RecordId }]>(
-		/* surql */ "CREATE ONLY $id",
-		{
+	const [output] = await surreal
+		.query(/* surql */ "CREATE ONLY $id", {
 			id: new StringRecordId("person:123"),
-		},
-	);
+		})
+		.execute<{ id: RecordId }>();
 
 	expect(output.id).toStrictEqual(new RecordId("person", 123));
 });
@@ -593,12 +609,11 @@ test("string record id", async () => {
 test("table", async () => {
 	const surreal = await createSurreal();
 
-	const [output] = await surreal.query<[Table]>(
-		/* surql */ "RETURN type::table($table)",
-		{
+	const [output] = await surreal
+		.query(/* surql */ "RETURN type::table($table)", {
 			table: "person",
-		},
-	);
+		})
+		.execute<Table>();
 
 	expect(output).toStrictEqual(new Table("person"));
 });

--- a/tests/integration/tests/querying.test.ts
+++ b/tests/integration/tests/querying.test.ts
@@ -469,6 +469,7 @@ describe("template literal", async () => {
 			["; RETURN [$foo, $bar, $1, $foo, $bar, $2]"],
 			[{ foo: foo, bar: bar, "1": 1, "2": 2 }],
 		);
+
 		expect(Object.keys(query.bindings)).toStrictEqual([
 			"bind___0",
 			"bind___1",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?
This pull request aims to make the query function and the PreparedQuery class more type safe. This includes auto-completion for query bindings and basic type validation for binding values to reduce mistakes.

### Limitations?
While working on this request, I came across some limitations of typescript. 
####  TemplateStringsArray
As described here [https://github.com/microsoft/TypeScript/issues/33304](url) until now typescript can't be used with type safe TemplateStringsArray. This creates some limitations. 
First example:
```ts
// so for example surql cant be infered correctly 
	const query = surql`RETURN [${foo},${bar}, ${1}, ${foo}, ${bar}, ${2}]`;
// instead  we need to use  the PreparedQuery Class for full typesafety  
		const query = new PreparedQuery("RETURN [$foo,$bar, $1, $foo, $bar, $2]", {
			foo: foo,
			bar: bar,
			"1": 1,
			"2": 2,
		});
   query.append([";Select * from sometable where hello_world = $helloWorld"], [{helloWorld: "Hello World"}])
        const bindings = query.bindings


```
<img width="192" alt="image" src="https://github.com/user-attachments/assets/ef90522c-19bc-472d-9599-ba08dd0f1a78" />


Second example, value validation can't be inferred correctly:
```ts
// this example can be validated. 
//The expected error would be to use r`some:record`  instead of "some:record" to ensure the correct encoding
await surreal.query("Select * From  $record", {
record : "some:record"
}).execute()

// this example cant be validated correctly by typscript because of the TemplateStringsArray
await surreal.query("Select * From  $record", {
record : s`some:record`
}).execute()

```
A workaround would be to create a ESLint/biome extension to ensure proper value checking for query bindings.

### partial generic type arguments 
As described here [https://github.com/microsoft/TypeScript/issues/10571](url) typescript doesn't support partial generic type arguments. This introduces the
problem when passing the return generic to query, for example
 ```ts 
//Typescript errors because it also expects the other generics. 
const [output] = await surreal
		.query<returnValue>(/* surql */ "CREATE ONLY $id", {
			id: new RecordId("person", 90071992547409915n),
		})

//To work around this, we need to make a significant change to the query method. 

const [output] = await surreal
		.query(/* surql */ "CREATE ONLY $id", {
			id: new RecordId("person", 90071992547409915n),
		})
		.execute<{ id: RecordId }>();
```

### DB parameters

The last limitations are DB parameters.  To make the query fully type safe, we need to know what params are set on the server. This could be achieved by adding runtime overhead inside the SDK by creating an object that will be inferred. This requires updating it when using the let and unset function, and fetch the params from the DB every time the use function is called.
Another approach would be to add a CLI tool with a watch mode similar to GraphQL-gen that generates the typescript types from the DB. 


## What does this change do?
Add typescript auto-completion for binding keys, value validation for strings including: UUID, Date, Record, Future. Optional bindings for rust function params. Excluding bindings for reserved variables like auth.
Add type safety for: 
```ts   
const query = new PreparedQuery("Select * from table where id  = $id", {
	id: "",
});

const updatedQuery = query.append(
	[
		"Select * from hello world where hello_word = $hello_world",
		"Select * from test where hello_world_2 = $hello_world_2",
	],
	[{ hello_world: "some" }, { hello_world_2: "" }],
);
const bindings = updatedQuery.bindings;
```
 ```ts
 await surreal
		.query(/* surql */ "CREATE ONLY $id", {
			id: new RecordId("person", 90071992547409915n),
		})
		.execute<{ id: RecordId }>();
```

Adding a new query function for many queries this is useful when you write your query for example in surql files and just import them. The functions take in many surql statements and merges them into a single one.
```ts
    await surreal.queryMany([someSurqlQuery, someSurqlQuery],[someBindings,someBidnings ])

```

Final change: changing <T extends unknown []> to  <T extends unknown[T]>

that's more a personal opinion, but I think that it's more intuitive than wrapping the response type in []

## What is your testing strategy?

I played around with the SDK and a local surrealdb instance but didn't found any unexpected errors.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb.js/blob/main/CONTRIBUTING.md)
